### PR TITLE
Make example compile, fix warnings, make clippy happy, format

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -62,8 +62,8 @@ impl GPIO {
             .write(true)
             .open(format!("{}gpio{}/direction", GPIO_PATH, self.pin))?;
         match mode {
-            GPIOMode::Read => try!(direction.write_all("in".as_bytes())),
-            GPIOMode::Write => try!(direction.write_all("out".as_bytes())),
+            GPIOMode::Read => direction.write_all("in".as_bytes())?,
+            GPIOMode::Write => direction.write_all("out".as_bytes())?,
         };
         self.mode = mode;
         Ok(self)
@@ -96,13 +96,11 @@ impl GPIO {
     /// Reads the current value of the pin in both Read and Write mode.
     /// Returns an Error if a value other than "1" or "0" is read
     pub fn value(&self) -> Result<GPIOData> {
-        let mut value = try!(
-            OpenOptions::new()
-                .read(true)
-                .open(format!("{}gpio{}/value", GPIO_PATH, self.pin))
-        );
+        let mut value = OpenOptions::new()
+            .read(true)
+            .open(format!("{}gpio{}/value", GPIO_PATH, self.pin))?;
         let mut buffer = vec![];
-        try!(value.read_to_end(&mut buffer));
+        value.read_to_end(&mut buffer)?;
         match buffer[0] as char {
             '0' => Ok(GPIOData::Low),
             '1' => Ok(GPIOData::High),
@@ -129,7 +127,7 @@ impl GPIO {
         let mut direction = OpenOptions::new()
             .write(true)
             .open(format!("{}gpio{}/value", GPIO_PATH, self.pin))?;
-        try!(direction.write_all(buffer.as_bytes()));
+        direction.write_all(buffer.as_bytes())?;
         Ok(())
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -87,7 +87,7 @@ impl GPIO {
         }
         let mut result = GPIO {
             pin: gpio,
-            mode: mode,
+            mode,
         };
         result.set_mode(mode)?;
         Ok(result)
@@ -139,9 +139,8 @@ impl Drop for GPIO {
             .write(true)
             .open(format!("{}unexport", GPIO_PATH))
         {
-            match unexport.write_all(format!("{}", self.pin).as_bytes()) {
-                Err(why) => panic!("couldn't close gpio {}: {}", self.pin, why),
-                Ok(_) => {}
+            if let Err(why) = unexport.write_all(format!("{}", self.pin).as_bytes()) {
+                panic!("couldn't close gpio {}: {}", self.pin, why)
             }
         } else {
             panic!("file error: {}")

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -17,13 +17,13 @@
 // You should have received a copy of the GNU General Public License
 // along with RustpiIO.  If not, see <http://www.gnu.org/licenses/>
 
+use std::fmt;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
-use std::io::Result;
-use std::io::ErrorKind;
 use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Result;
 use std::path::Path;
-use std::fmt;
 
 use globals::GPIO_PATH;
 
@@ -85,10 +85,7 @@ impl GPIO {
                 .open(format!("{}export", GPIO_PATH))?;
             export.write_all(format!("{}", gpio).as_bytes())?;
         }
-        let mut result = GPIO {
-            pin: gpio,
-            mode,
-        };
+        let mut result = GPIO { pin: gpio, mode };
         result.set_mode(mode)?;
         Ok(result)
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -132,15 +132,16 @@ impl GPIO {
 /// Closes the gpio and write its pin number into /sys/class/gpio/unexport
 impl Drop for GPIO {
     fn drop(&mut self) {
-        if let Ok(mut unexport) = OpenOptions::new()
+        match OpenOptions::new()
             .write(true)
             .open(format!("{}unexport", GPIO_PATH))
         {
-            if let Err(why) = unexport.write_all(format!("{}", self.pin).as_bytes()) {
-                panic!("couldn't close gpio {}: {}", self.pin, why)
+            Ok(mut unexport) => {
+                if let Err(why) = unexport.write_all(format!("{}", self.pin).as_bytes()) {
+                    panic!("couldn't close gpio {}: {}", self.pin, why)
+                }
             }
-        } else {
-            panic!("file error: {}")
+            Err(why) => panic!("file error: {}", why),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ fn main() {
         Err(e) => panic!("{:?}", e),
     };
     let mut value: u8 = 1;
-    for n in 1..100 {
+    for _ in 1..100 {
         value = 1 - value;
         let data = match value {
             0 => GPIOData::Low,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,14 @@ Build for the Raspberry with `cargo build --target=arm-unknown-linux-gnueabihf`
 
 ```
  extern crate rustpi_io;
- use rustpi_io::*;
+ use rustpi_io::gpio::{GPIO, GPIOData, GPIOMode};
 
  fn main() {
-     let gpio2 = match GPIO::init(2, GPIOMode::Write){
+     let gpio2 = match GPIO::new(2, GPIOMode::Write){
      Ok(result) => result,
      Err(e) => panic!("{:?}", e),
      };
-     let gpio3 = match GPIO::init(3, GPIOMode::Read){
+     let gpio3 = match GPIO::new(3, GPIOMode::Read){
          Ok(result) => result,
          Err(e) => panic!("{:?}", e),
      };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU General Public License
 // along with RustpiIO.  If not, see <http://www.gnu.org/licenses/>
 
-/*! 
+/*!
 RustpiIO is a library to read and write to the SPI bus and the GPIO pins of a Raspberry Pi.
 
 It uses the system interface under /sys/class/gpio/ provided by the linux OS for the gpios. And wraps [spidev](https://crates.io/crates/spidev) for the serial interface.
@@ -31,49 +31,49 @@ There is also an interface to read out the [revision codes](https://www.raspberr
 
 # Installation
 To compile a raspberry pi program you need to prepare a cross compiler for rust
-(for the older pi processors try `*gnueabi` instead of `*gnueabihf`):  
-`rustup target add arm-unknown-linux-gnueabihf`  
-`sudo apt-get install gcc-arm-linux-gnueabihf`  
+(for the older pi processors try `*gnueabi` instead of `*gnueabihf`):
+`rustup target add arm-unknown-linux-gnueabihf`
+`sudo apt-get install gcc-arm-linux-gnueabihf`
 To tell the linker which program to use add the following lines to a corresponding
-./cargo/config file (like in this project)  
-`[target.arm-unknown-linux-gnueabihf]`  
-`linker="arm-linux-gnueabihf-gcc"`  
-Build for the Raspberry with `cargo build --target=arm-unknown-linux-gnueabihf`  
+./cargo/config file (like in this project)
+`[target.arm-unknown-linux-gnueabihf]`
+`linker="arm-linux-gnueabihf-gcc"`
+Build for the Raspberry with `cargo build --target=arm-unknown-linux-gnueabihf`
 
 
-# Example  
+# Example
 
 ```
- extern crate rustpi_io;
- use rustpi_io::gpio::{GPIO, GPIOData, GPIOMode};
+extern crate rustpi_io;
+use rustpi_io::gpio::{GPIOData, GPIOMode, GPIO};
 
- fn main() {
-     let gpio2 = match GPIO::new(2, GPIOMode::Write){
-     Ok(result) => result,
-     Err(e) => panic!("{:?}", e),
-     };
-     let gpio3 = match GPIO::new(3, GPIOMode::Read){
-         Ok(result) => result,
-         Err(e) => panic!("{:?}", e),
-     };
-     let mut value:u8 = 1;
-     for n in 1..100 {
-         value = 1-value;
-         let data = match value {
-             0 => GPIOData::Low,
-             1 => GPIOData::High,
-             _ => GPIOData::High
-         };
-         match gpio2.set(data) {
-             Ok(_) => {},
-             Err(e) => panic!("Error{:?}", e),
-         }
-         match gpio3.value(){
-             Ok(data) => println!("value: {}", data),
-             Err(e) => panic!("{:?}", e),
-         }
-     }
- }
+fn main() {
+    let gpio2 = match GPIO::new(2, GPIOMode::Write) {
+        Ok(result) => result,
+        Err(e) => panic!("{:?}", e),
+    };
+    let gpio3 = match GPIO::new(3, GPIOMode::Read) {
+        Ok(result) => result,
+        Err(e) => panic!("{:?}", e),
+    };
+    let mut value: u8 = 1;
+    for n in 1..100 {
+        value = 1 - value;
+        let data = match value {
+            0 => GPIOData::Low,
+            1 => GPIOData::High,
+            _ => GPIOData::High,
+        };
+        match gpio2.set(data) {
+            Ok(_) => {}
+            Err(e) => panic!("Error{:?}", e),
+        }
+        match gpio3.value() {
+            Ok(data) => println!("value: {}", data),
+            Err(e) => panic!("{:?}", e),
+        }
+    }
+}
 ```
 */
 

--- a/src/pi.rs
+++ b/src/pi.rs
@@ -21,13 +21,13 @@
 //! Based on https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
 //!
 
-use std::fmt;
-use std::io::Result;
-use std::fs::File;
-use std::io::Read;
-use std::io::ErrorKind;
-use std::io::Error;
 use globals::RASPI_INFO_PATH;
+use std::fmt;
+use std::fs::File;
+use std::io::Error;
+use std::io::ErrorKind;
+use std::io::Read;
+use std::io::Result;
 
 #[derive(Debug, PartialEq, PartialOrd)]
 pub enum RevisionStyle {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -208,7 +208,7 @@ impl SerialPi {
             })
             .lsb_first(false)
             .build();
-        try!(spi.configure(&options));
+        spi.configure(&options)?;
         Ok(SerialPi {
             device: spi,
             com_mode: communication_mode,
@@ -275,7 +275,7 @@ impl BufRead for SerialPi {
                         self.read_buffer.as_mut_slice().split_at_mut(buffer_length);
                     rest_buffer
                 };
-                try!(self.device.read(rest_buffer))
+                self.device.read(rest_buffer)?
             };
             self.read_buffer.truncate(buffer_length + bytes_read);
         }
@@ -314,7 +314,7 @@ impl Write for SerialPi {
             read_data.resize(buf.len(), 0 as u8);
             {
                 let mut transfer = SpidevTransfer::read_write(buf, read_data.as_mut_slice());
-                try!(self.device.transfer(&mut transfer));
+                self.device.transfer(&mut transfer)?;
             }
             self.read_buffer.append(&mut read_data);
             Ok(buf.len())

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -17,11 +17,13 @@
 // You should have received a copy of the GNU General Public License
 // along with RustpiIO.  If not, see <http://www.gnu.org/licenses/>
 
-use std::io;
-use std::io::{Error, ErrorKind};
-use spidev::{SPI_MODE_0, SPI_MODE_1, SPI_MODE_2, SPI_MODE_3, Spidev, SpidevOptions, SpidevTransfer};
 use globals::{SPI_PATH0, SPI_PATH1};
+use spidev::{
+    Spidev, SpidevOptions, SpidevTransfer, SPI_MODE_0, SPI_MODE_1, SPI_MODE_2, SPI_MODE_3,
+};
+use std::io;
 use std::io::{BufRead, Read, Write};
+use std::io::{Error, ErrorKind};
 
 /**
  * Correspond to the SPI Chip Enable Pins on the raspberry pi.
@@ -32,25 +34,25 @@ pub enum Device {
     CE1 = 1,
 }
 
-/** 
- From https://www.raspberrypi.org/documentation/hardware/raspberrypi/spi/README.md#driver  
- Possible Speeds:  
-    125.0 MHz  
-    62.5 MHz  
-    31.2 MHz  
-    15.6 MHz  
-    7.8 MHz  
-    3.9 MHz  
-    1953 kHz  
-    976 kHz  
-    488 kHz  
-    244 kHz  
-    122 kHz  
-    61 kHz  
-    30.5 kHz  
-    15.2 kHz  
-    7629 Hz  
- */
+/**
+From https://www.raspberrypi.org/documentation/hardware/raspberrypi/spi/README.md#driver
+Possible Speeds:
+   125.0 MHz
+   62.5 MHz
+   31.2 MHz
+   15.6 MHz
+   7.8 MHz
+   3.9 MHz
+   1953 kHz
+   976 kHz
+   488 kHz
+   244 kHz
+   122 kHz
+   61 kHz
+   30.5 kHz
+   15.2 kHz
+   7629 Hz
+*/
 #[derive(Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum Speed {
@@ -95,9 +97,9 @@ impl Speed {
 }
 
 /**
-The most common spi modes regulating the clock phase and polarity.  
-Mode 0 seems to be the most used one and is set as default.  
-See https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase for an explanation 
+The most common spi modes regulating the clock phase and polarity.
+Mode 0 seems to be the most used one and is set as default.
+See https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase for an explanation
 */
 #[derive(PartialEq, Default)]
 pub enum SpiMode {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -99,19 +99,13 @@ The most common spi modes regulating the clock phase and polarity.
 Mode 0 seems to be the most used one and is set as default.  
 See https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus#Clock_polarity_and_phase for an explanation 
 */
-#[derive(PartialEq)]
+#[derive(PartialEq, Default)]
 pub enum SpiMode {
+    #[default]
     Mode0,
     Mode1,
     Mode2,
     Mode3,
-}
-
-impl Default for SpiMode {
-    //* SpiMode::Mode0 */
-    fn default() -> Self {
-        SpiMode::Mode0
-    }
 }
 
 #[derive(PartialEq)]
@@ -247,7 +241,7 @@ impl Read for SerialPi {
         self.read_buffer.drain(0..buffer_read_count);
         if buffer_read_count < buf.len() {
             let (_, rest_buffer) = buf.split_at_mut(buffer_read_count);
-            buffer_read_count = buffer_read_count + self.device.read(rest_buffer)?;
+            buffer_read_count += self.device.read(rest_buffer)?;
         }
         Ok(buffer_read_count)
     }
@@ -310,8 +304,7 @@ impl Write for SerialPi {
         if self.com_mode == ComMode::HalfDuplex {
             self.device.write(buf)
         } else {
-            let mut read_data: Vec<u8> = Vec::with_capacity(buf.len());
-            read_data.resize(buf.len(), 0 as u8);
+            let mut read_data: Vec<u8> = vec![0_u8; buf.len()];
             {
                 let mut transfer = SpidevTransfer::read_write(buf, read_data.as_mut_slice());
                 self.device.transfer(&mut transfer)?;


### PR DESCRIPTION
Most importantly this makes the example code run. After that I made improvements based on compiler warnings and clippy. Finally I ran `cargo fmt` to format everything.