### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock


### PR DESCRIPTION
This adds a `.gitignore` file just like the one that comes with a new project created with `cargo new --lib project_name`.

This way git will not recognize compiled files in the `target` directory as something we may want to commit.

Having the `Cargo.lock` file listed in the `.gitignore` file is optional but it probably should either be listed in the `.gitignore` file or itself be checked into version control. Consumers of libraries will ignore our `Cargo.lock` file either way. Having the `Cargo.lock` file itself checked in would ensure that you and I would build with the exact same version of dependencies while developing this crate (for better or worse).