### PR TITLE
Cleanup panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,34 +23,23 @@ Build for the Raspberry with `cargo build --target=arm-unknown-linux-gnueabihf`
 # Example  
 
 ```
- extern crate rustpi_io;
- use rustpi_io::*;
+extern crate rustpi_io;
+use rustpi_io::gpio::{GPIOData, GPIOMode, GPIO};
 
- fn main() {
-     let gpio2 = match GPIO::new(2, GPIOMode::Write){
-     Ok(result) => result,
-     Err(e) => panic!("{:?}", e),
-     };
-     let gpio3 = match GPIO::new(3, GPIOMode::Read){
-         Ok(result) => result,
-         Err(e) => panic!("{:?}", e),
-     };
-     let mut value:u8 = 1;
-     for n in 1..100 {
-         value = 1-value;
-         let data = match value {
-             0 => GPIOData::Low,
-             1 => GPIOData::High,
-             _ => GPIOData::High
-         };
-         match gpio2.set(data) {
-             Ok(_) => {},
-             Err(e) => panic!("Error{:?}", e),
-         }
-         match gpio3.value(){
-             Ok(data) => println!("value: {}", data),
-             Err(e) => panic!("{:?}", e),
-         }
-     }
- }
+fn main() {
+    let gpio2 = GPIO::new(2, GPIOMode::Write).unwrap();
+    let gpio3 = GPIO::new(3, GPIOMode::Read).unwrap();
+    let mut value: u8 = 1;
+    for _ in 1..100 {
+        value = 1 - value;
+        let data = match value {
+            0 => GPIOData::Low,
+            1 => GPIOData::High,
+            _ => GPIOData::High,
+        };
+        gpio2.set(data).unwrap();
+        let data = gpio3.value().unwrap();
+        println!("value: {}", data);
+    }
+}
 ```

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -132,17 +132,12 @@ impl GPIO {
 /// Closes the gpio and write its pin number into /sys/class/gpio/unexport
 impl Drop for GPIO {
     fn drop(&mut self) {
-        match OpenOptions::new()
+        OpenOptions::new()
             .write(true)
             .open(format!("{}unexport", GPIO_PATH))
-        {
-            Ok(mut unexport) => {
-                if let Err(why) = unexport.write_all(format!("{}", self.pin).as_bytes()) {
-                    panic!("couldn't close gpio {}: {}", self.pin, why)
-                }
-            }
-            Err(why) => panic!("file error: {}", why),
-        }
+            .expect("file error")
+            .write_all(format!("{}", self.pin).as_bytes())
+            .unwrap_or_else(|why| panic!("couldn't close gpio {}: {}", self.pin, why));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,14 +48,8 @@ extern crate rustpi_io;
 use rustpi_io::gpio::{GPIOData, GPIOMode, GPIO};
 
 fn main() {
-    let gpio2 = match GPIO::new(2, GPIOMode::Write) {
-        Ok(result) => result,
-        Err(e) => panic!("{:?}", e),
-    };
-    let gpio3 = match GPIO::new(3, GPIOMode::Read) {
-        Ok(result) => result,
-        Err(e) => panic!("{:?}", e),
-    };
+    let gpio2 = GPIO::new(2, GPIOMode::Write).unwrap();
+    let gpio3 = GPIO::new(3, GPIOMode::Read).unwrap();
     let mut value: u8 = 1;
     for _ in 1..100 {
         value = 1 - value;
@@ -64,14 +58,9 @@ fn main() {
             1 => GPIOData::High,
             _ => GPIOData::High,
         };
-        match gpio2.set(data) {
-            Ok(_) => {}
-            Err(e) => panic!("Error{:?}", e),
-        }
-        match gpio3.value() {
-            Ok(data) => println!("value: {}", data),
-            Err(e) => panic!("{:?}", e),
-        }
+        gpio2.set(data).unwrap();
+        let data = gpio3.value().unwrap();
+        println!("value: {}", data);
     }
 }
 ```


### PR DESCRIPTION
Use expect and unwraps instead of match statements and panic macros where possible.